### PR TITLE
Fix for #194 - Returning empty string causes an exception

### DIFF
--- a/src/Transformers/Response.php
+++ b/src/Transformers/Response.php
@@ -124,8 +124,10 @@ class Response
      */
     protected function sendInChunk($content)
     {
-        foreach (str_split($content, 1024) as $v) {
-            $this->swooleResponse->write($v);
+        if ($content) {
+            foreach (str_split($content, 1024) as $v) {
+                $this->swooleResponse->write($v);
+            }
         }
         $this->swooleResponse->end();
     }


### PR DESCRIPTION
Work around issue where you want to return no content. #194