### PR TITLE
add dump Helpers

### DIFF
--- a/src/Helpers/Dump.php
+++ b/src/Helpers/Dump.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace SwooleTW\Http\Helpers;
+
+
+class Dump
+{
+    // define the dumper class
+    protected static $dumper_class = 'Symfony\Component\VarDumper\Dumper\HtmlDumper';
+    protected static $cloner_class = 'Symfony\Component\VarDumper\Cloner\VarCloner';
+
+    public static function dd(...$args) {
+
+        // only works when these classes are existing
+        // otherwise return false
+        if (!class_exists(static::$dumper_class) || !class_exists(static::$cloner_class)) {
+            return false;
+        }
+
+        // init the dumper and cloner
+        $dumper = new static::$dumper_class();
+        $cloner = new static::$cloner_class();
+
+        // dump each var in the args
+        foreach ($args as $arg) {
+            if (defined('IN_PHPUNIT')) {
+                continue;
+            }
+            $dumper->dump($cloner->cloneVar($arg));
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
added a Helper class `\SwooleTW\Http\Helpers\Dump` to mimic the dd() action.

sample:
```php
\SwooleTW\Http\Helpers\Dump::dd('a', 'b', ['app', 'dump', 'c'], (object)['a'=>1, 'b'=>2]);
```

output:
<img width="245" alt="Screen Shot 2019-04-06 at 10 02 18 pm" src="https://user-images.githubusercontent.com/8447539/55668663-b7a85580-58b8-11e9-8360-d2359d8efd87.png">
