### PR TITLE
a rare bug fixing

### DIFF
--- a/src/Server/PidManager.php
+++ b/src/Server/PidManager.php
@@ -61,7 +61,7 @@ class PidManager
             // the pid file only contains one pid number while the newer version requires two
             // then the swoole:http command would encounter a bug which the array index 1 is inaccessible
             if (count($pids) !== 2) {
-                $pids = [];
+                $pids = [0, 0];
             }
         }
 

--- a/src/Server/PidManager.php
+++ b/src/Server/PidManager.php
@@ -56,6 +56,13 @@ class PidManager
         if (is_readable($this->pidFile)) {
             $content = file_get_contents($this->pidFile);
             $pids = explode(',', $content);
+
+            // when upgraded from an old version with a running swoole:http
+            // the pid file only contains one pid number while the newer version requires two
+            // then the swoole:http command would encounter a bug which the array index 1 is inaccessible
+            if (count($pids) !== 2) {
+                $pids = [];
+            }
         }
 
         return $pids;


### PR DESCRIPTION
I upgraded from an older version to the latest version
and found that the swoole:http cannot start or stop
the console output said the index is inaccessible for an array

I dug into the code and found the new pidmanager would write two pid numbers into the pid file
and my current pid file only contains one. I guess because I did not stop the swoole:http and upgraded the packaged directly, then I got the old version pid file and new pid manager did not recognise it. **This issue solved by remove the existing pid file.**

I added a length checkup, if the length is not 2, it returns `[0, 0]` for a temp allowance to start/stop/restart the server.

This situation should be very rare, and this is a not an ideal solution, mabye throw an incompatible error and display the correct solution is much better.