### PR TITLE
Set request for auth handler in websocket middleware

### DIFF
--- a/src/Websocket/Middleware/Authenticate.php
+++ b/src/Websocket/Middleware/Authenticate.php
@@ -42,6 +42,7 @@ class Authenticate
     public function handle($request, Closure $next)
     {
         try {
+            $this->auth->setRequest($request);
             if ($user = $this->auth->authenticate()) {
                 $request->setUserResolver(function () use ($user) {
                     return $user;


### PR DESCRIPTION
Hi,
I may be wrong with this, the environment is new for me.

When I tried to implement authentication in websocket connection using the provided middleware, I ran into the problem that the request variable in the guard did not contain the parameters I sent (and was available in the websocket connect event).
I'm not sure why this is needed, but after like a hour I found out that I can set the request directly for the guard in the middleware, only by adding: $this->auth->setRequest($request).

I know that the middleware is only a boilerplate, but this may save hours for others.