### PR TITLE
Fix unqueueing cookies

### DIFF
--- a/src/Server/Resetters/ResetCookie.php
+++ b/src/Server/Resetters/ResetCookie.php
@@ -20,7 +20,7 @@ class ResetCookie implements ResetterContract
         if (isset($app['cookie'])) {
             $cookies = $app->make('cookie');
             foreach ($cookies->getQueuedCookies() as $key => $value) {
-                $cookies->unqueue($key);
+                $cookies->unqueue($value->getName());
             }
         }
 


### PR DESCRIPTION
This seems to have changed in Laravel 6.
The key is just the array index of the queued cookie, but `unqueue` takes the name of the cookie, and as a result, no cookies are actually unqueued.