### PR TITLE
Fix memory leak - clear context after disabling sandbox

### DIFF
--- a/src/Server/Sandbox.php
+++ b/src/Server/Sandbox.php
@@ -324,8 +324,8 @@ class Sandbox
      */
     public function disable()
     {
-        Context::clear();
         $this->setInstance($this->getBaseApp());
+        Context::clear();
     }
 
     /**


### PR DESCRIPTION
Calling `Context::setApp` after disabling the sandbox (which is supposed to clear the context) causes that entry to be set again in the `$apps` array. This leaks a booted app, since `Coroutine::getuid()` is monotonic.