### PR TITLE
Fix Content-Type when static file w/o extension name

### DIFF
--- a/src/Helpers/MimeType.php
+++ b/src/Helpers/MimeType.php
@@ -805,7 +805,7 @@ class MimeType
      */
     public static function get($extension = null)
     {
-        return $extension ? self::getMimeTypeFromExtension($extension) : self::$mimes;
+        return isset($extension) ? self::getMimeTypeFromExtension($extension) : self::$mimes;
     }
 
     /**

--- a/tests/Helpers/MimeTypeTest.php
+++ b/tests/Helpers/MimeTypeTest.php
@@ -14,6 +14,14 @@ class MimeTypeTest extends TestCase
 
         $this->assertEquals($mimetype, 'text/css');
     }
+    
+    public function testGetWithEmptyString()
+    {
+        $extension = '';
+        $mimetype = MimeType::get($extension);
+
+        $this->assertEquals($mimetype, 'application/octet-stream');
+    }
 
     public function testFrom()
     {


### PR DESCRIPTION
When the static file w/o extension name, server will return text/html as it Content-Type.
I fix the condition of Mime::get function and add new test case.