### PR TITLE
Replace FatalThrowableError with FatalError

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -23,7 +23,7 @@ use SwooleTW\Http\Concerns\InteractsWithWebsocket;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use SwooleTW\Http\Concerns\InteractsWithSwooleQueue;
 use SwooleTW\Http\Concerns\InteractsWithSwooleTable;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\ErrorHandler\Error\FatalError;
 
 /**
  * Class Manager
@@ -411,7 +411,23 @@ class Manager
     protected function normalizeException(Throwable $e)
     {
         if (! $e instanceof Exception) {
-            $e = new FatalThrowableError($e);
+			if ($e instanceof \ParseError) {
+				$severity = E_PARSE;
+			} elseif ($e instanceof \TypeError) {
+				$severity = E_RECOVERABLE_ERROR;
+			} else {
+				$severity = E_ERROR;
+			}
+		
+			//error_get_last() syntax
+			$error = [
+				'type' => $severity,
+				'message' => $e->getMessage(),
+				'file' => $e->getFile(),
+				'line' => $e->getLine(),
+			];
+			
+            $e = new FatalError($e->getMessage(), $e->getCode(), $error, null, true, $e->getTrace());
         }
 
         return $e;


### PR DESCRIPTION
Debug component was deprecated and replaced by ErrorHandler in Symfony 4.4. Laravel 7 uses a Symfony 5 which does not contain Debug anymore, therefore app crashes.
ErrorHandler does not have a similar class, therefore I extracted a little bit of logic from the old FatalThrowableError to construct a FatalError object.