### PR TITLE
Reset websocket connection after trying to emit to a non-existing room

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -23,7 +23,7 @@ use SwooleTW\Http\Concerns\InteractsWithWebsocket;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use SwooleTW\Http\Concerns\InteractsWithSwooleQueue;
 use SwooleTW\Http\Concerns\InteractsWithSwooleTable;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Symfony\Component\ErrorHandler\Error\FatalError;
 
 /**
  * Class Manager
@@ -411,7 +411,23 @@ class Manager
     protected function normalizeException(Throwable $e)
     {
         if (! $e instanceof Exception) {
-            $e = new FatalThrowableError($e);
+			if ($e instanceof \ParseError) {
+				$severity = E_PARSE;
+			} elseif ($e instanceof \TypeError) {
+				$severity = E_RECOVERABLE_ERROR;
+			} else {
+				$severity = E_ERROR;
+			}
+		
+			//error_get_last() syntax
+			$error = [
+				'type' => $severity,
+				'message' => $e->getMessage(),
+				'file' => $e->getFile(),
+				'line' => $e->getLine(),
+			];
+			
+            $e = new FatalError($e->getMessage(), $e->getCode(), $error, null, true, $e->getTrace());
         }
 
         return $e;

--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -23,7 +23,7 @@ use SwooleTW\Http\Concerns\InteractsWithWebsocket;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use SwooleTW\Http\Concerns\InteractsWithSwooleQueue;
 use SwooleTW\Http\Concerns\InteractsWithSwooleTable;
-use Symfony\Component\ErrorHandler\Error\FatalError;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * Class Manager
@@ -411,23 +411,7 @@ class Manager
     protected function normalizeException(Throwable $e)
     {
         if (! $e instanceof Exception) {
-			if ($e instanceof \ParseError) {
-				$severity = E_PARSE;
-			} elseif ($e instanceof \TypeError) {
-				$severity = E_RECOVERABLE_ERROR;
-			} else {
-				$severity = E_ERROR;
-			}
-		
-			//error_get_last() syntax
-			$error = [
-				'type' => $severity,
-				'message' => $e->getMessage(),
-				'file' => $e->getFile(),
-				'line' => $e->getLine(),
-			];
-			
-            $e = new FatalError($e->getMessage(), $e->getCode(), $error, null, true, $e->getTrace());
+            $e = new FatalThrowableError($e);
         }
 
         return $e;

--- a/src/Websocket/Websocket.php
+++ b/src/Websocket/Websocket.php
@@ -170,6 +170,7 @@ class Websocket
         // that means trying to emit to a non-existing room
         // skip it directly instead of pushing to a task queue
         if (empty($fds) && $assigned) {
+            $this->reset();
             return false;
         }
 


### PR DESCRIPTION
If I am trying to emit an event to a non-existing room, the emit function skips the task, but does not reset the data. Therefore, if I am unaware of the room not existing and later try to send a reply to the current connection (without setting the to param), it will still be treated as if I am trying to emit to the non-existing room and will seem like the connection is dead as no exception is thrown.