### PR TITLE
fix: modify Dumper.php file class name.

### DIFF
--- a/src/Helpers/Dumper.php
+++ b/src/Helpers/Dumper.php
@@ -6,7 +6,7 @@ use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
-class VarDumper
+class Dumper
 {
     protected static $cloner;
 


### PR DESCRIPTION
Operation `composer du -o` or `composer install` ..., `src/Helpers/Dumper.php` The class name and file name in it are inconsistent and do not conform to the psr-4 specification. Composer will prompt a notification, of course, it does not affect the entire function. It is recommended to fix it and keep the class name and file name consistent.

```shell
Deprecation Notice: Class SwooleTW\Http\Helpers\VarDumper located in ./vendor/swooletw/laravel-swoole/src/Helpers/Dumper.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/Cellar/composer/1.10.6/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```