### PR TITLE
Support for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
   ],
   "require": {
     "php": "^7.2",
-    "illuminate/console": "~5.4|~6.0|~7.0",
-    "illuminate/contracts": "~5.4|~6.0|~7.0",
-    "illuminate/http": "~5.4|~6.0|~7.0",
-    "illuminate/support": "~5.4|~6.0|~7.0",
+    "illuminate/console": "~5.4|~6.0|~7.0|~8.0",
+    "illuminate/contracts": "~5.4|~6.0|~7.0|~8.0",
+    "illuminate/http": "~5.4|~6.0|~7.0|~8.0",
+    "illuminate/support": "~5.4|~6.0|~7.0|~8.0",
     "predis/predis": "^1.1"
   },
   "require-dev": {
-    "laravel/lumen-framework": "~5.4|~6.0|~7.0",
+    "laravel/lumen-framework": "~5.4|~6.0|~7.0|~8.0",
     "phpunit/phpunit": "^7.5",
     "phpunit/php-code-coverage": "^6.1",
     "php-coveralls/php-coveralls": "^2.1",


### PR DESCRIPTION
New version was [released](https://laravel.com/docs/8.x/releases).
As far as I know there are no breaking changes that should affect this package.