### PR TITLE
Add auth to the pre_resolved as default

### DIFF
--- a/config/swoole_http.php
+++ b/config/swoole_http.php
@@ -81,7 +81,7 @@ return [
     'pre_resolved' => [
         'view', 'files', 'session', 'session.store', 'routes',
         'db', 'db.factory', 'cache', 'cache.store', 'config', 'cookie',
-        'encrypter', 'hash', 'router', 'translator', 'url', 'log',
+        'encrypter', 'hash', 'router', 'translator', 'url', 'log', 'auth',
     ],
 
     /*


### PR DESCRIPTION
As many apps uses the **auth** instances, it could be usefull if auth was cleaned at every request as default. I do this change in every new installation of this package for example.