### PR TITLE
Add event swoole.beforeStart to be able to bind server events

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -134,6 +134,8 @@ class Manager
 
             $server->on($event, $callback);
         }
+        
+        $this->container->make('events')->dispatch('swoole.beforeStart', $server);
     }
 
     /**


### PR DESCRIPTION
Currently, there is no way to bind events on the server instance, as there is no way to retrieve it in a 'created, but not started yet' state. Therefore I added dispatching of swoole.beforeStart event.