### PR TITLE
Fix incorrect SWOOLE_PROCESS value

### DIFF
--- a/src/Server/helpers.php
+++ b/src/Server/helpers.php
@@ -18,5 +18,5 @@ if (! defined('SWOOLE_SOCK_TCP')) {
 }
 
 if (! defined('SWOOLE_PROCESS')) {
-    define('SWOOLE_PROCESS', 3);
+    define('SWOOLE_PROCESS', 2);
 }


### PR DESCRIPTION
Hello, I found a bug that the `SWOOLE_PROCESS` value is incorrect.
In swoole `MODE_PROCESS` is `2`, not `3`.

See: https://github.com/swoole/swoole-src/blob/b09a7e9acb2c19c91f2c69df449c9fa77be5d010/include/swoole_server.h#L511
 and https://github.com/swoole/swoole-src/blob/b09a7e9acb2c19c91f2c69df449c9fa77be5d010/ext-src/php_swoole.cc#L426

In some cases, It will get an error when running a server with `SWOOLE_PROCESS` on `swoole_http.php` config file.
It will show `Swoole\Server::__construct(): invalid $mode parameters 3`

See: https://github.com/swoole/swoole-src/blob/b09a7e9acb2c19c91f2c69df449c9fa77be5d010/ext-src/swoole_server.cc#L1994
