### PR TITLE
Add a SSL port for http and https to work on multiple port

### DIFF
--- a/config/swoole_http.php
+++ b/config/swoole_http.php
@@ -12,12 +12,13 @@ return [
     'server' => [
         'host' => env('SWOOLE_HTTP_HOST', '127.0.0.1'),
         'port' => env('SWOOLE_HTTP_PORT', '1215'),
+        // You must add --enable-openssl while compiling Swoole
+        // Put ssl_port > 0 if you want to enable SSL
+        'ssl_port' => env('SWOOLE_HTTP_PORT', '0'),
         'public_path' => base_path('public'),
         // Determine if to use swoole to respond request for static files
         'handle_static_files' => env('SWOOLE_HANDLE_STATIC', true),
         'access_log' => env('SWOOLE_HTTP_ACCESS_LOG', false),
-        // You must add --enable-openssl while compiling Swoole
-        // Put `SWOOLE_SOCK_TCP | SWOOLE_SSL` if you want to enable SSL
         'socket_type' => SWOOLE_SOCK_TCP,
         'process_type' => SWOOLE_PROCESS,
         'options' => [

--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -102,11 +102,15 @@ class HttpServerCommand extends Command
 
         $host = Arr::get($this->config, 'server.host');
         $port = Arr::get($this->config, 'server.port');
+        $ssl_port = Arr::get($this->config, 'server.ssl_port');
         $hotReloadEnabled = Arr::get($this->config, 'hot_reload.enabled');
         $accessLogEnabled = Arr::get($this->config, 'server.access_log');
 
         $this->info('Starting swoole http server...');
         $this->info("Swoole http server started: <http://{$host}:{$port}>");
+        if(intval($ssl_port) > 0)
+            $this->info("Swoole https server started: <https://{$host}:{$ssl_port}>");
+
         if ($this->isDaemon()) {
             $this->info(
                 '> (You can run this command to ensure the ' .

--- a/src/HttpServiceProvider.php
+++ b/src/HttpServiceProvider.php
@@ -167,10 +167,14 @@ abstract class HttpServiceProvider extends ServiceProvider
         $config = $this->app->make('config');
         $host = $config->get('swoole_http.server.host');
         $port = $config->get('swoole_http.server.port');
+        $ssl_port = $config->get('swoole_http.server.ssl_port');
         $socketType = $config->get('swoole_http.server.socket_type', SWOOLE_SOCK_TCP);
         $processType = $config->get('swoole_http.server.process_type', SWOOLE_PROCESS);
 
         static::$server = new $server($host, $port, $processType, $socketType);
+
+        if(intval($ssl_port) > 0)
+            static::$server->listen($host, $ssl_port, SWOOLE_SOCK_TCP | SWOOLE_SSL );
     }
 
     /**


### PR DESCRIPTION
Hello
When I activate the SSL for HTTPS operation then HTTP is no longer responsible on that port.
So I added the ssl port to work with both HTTP and HTTPS protocols at the same time.
For example, HTTP can be performed on 80 and HTTPS on 443.

---------------------------------------------------------------------
Swoole Listening On Multiple Ports:
https://www.swoole.co.uk/docs/modules/swoole-server/multiple-ports