### PR TITLE
feat: add hook action for http server

### DIFF
--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -70,6 +70,7 @@ class HttpServerCommand extends Command
         $this->checkEnvironment();
         $this->loadConfigs();
         $this->initAction();
+        $this->hookAction();
         $this->runAction();
     }
 
@@ -79,6 +80,14 @@ class HttpServerCommand extends Command
     protected function loadConfigs()
     {
         $this->config = $this->laravel->make('config')->get('swoole_http');
+    }
+    
+    /**
+     * Hook action
+     */
+    protected function hookAction()
+    {
+        // custom hook task before starting server
     }
 
     /**


### PR DESCRIPTION
Previously, there is no way (?) to hook up and run a script before http start.

This patch allowed user to extends our class with `hookAction` run custom script before starting server up.