### PR TITLE
Respond with 503 when app is not settled

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -212,6 +212,14 @@ class Manager
             if ($handleStatic && Request::handleStatic($swooleRequest, $swooleResponse, $publicPath)) {
                 return;
             }
+
+            // Respond with 503 if app is not settled by worker
+            if (!$sandbox->isSettledApp()) {
+                Response::make((new \Illuminate\Http\Response())->setStatusCode(503), $swooleResponse)
+                    ->send();
+                return;
+            }
+
             // transform swoole request to illuminate request
             $illuminateRequest = Request::make($swooleRequest)->toIlluminate();
 

--- a/src/Server/Sandbox.php
+++ b/src/Server/Sandbox.php
@@ -48,6 +48,11 @@ class Sandbox
         $this->initialize();
     }
 
+    public function isSettledApp()
+    {
+        return !!$this->app;
+    }
+
     /**
      * Set framework type.
      *


### PR DESCRIPTION
Hi! I caught errors when starting the server and refresh the page quickly.
The problem answer is different timing to start-up onRequest and onWorkerStart.
The `bindToLaravelApp` is not called by onWorkerStart when starting the server and access the page quickly.
Therefore, `$app` field is null for a certain period of time.

I caught errors are here:

![2021-03-07_at_10_49_04](https://user-images.githubusercontent.com/1282995/110227196-22e18300-7f39-11eb-91f8-745236437647.jpg)
![2021-03-07_at_10_49_21](https://user-images.githubusercontent.com/1282995/110227197-24ab4680-7f39-11eb-941c-5cb223e866d0.jpg)