### PR TITLE
Recommit maybe a bug

### DIFF
--- a/src/Websocket/Pusher.php
+++ b/src/Websocket/Pusher.php
@@ -68,7 +68,7 @@ class Pusher
         bool $broadcast,
         bool $assigned,
         string $event,
-        $message = null,
+        string $message,
         $server
     )
     {


### PR DESCRIPTION
Recommit, add `string` type to `$message`. This style of function declaration [has been deprecated in PHP 8.0](https://www.php.net/manual/en/migration80.deprecated.php).

solve issue: **[Is this a BUG?](https://github.com/swooletw/laravel-swoole/issues/472)** 