### PR TITLE
Update Pusher.php

### DIFF
--- a/src/Websocket/Pusher.php
+++ b/src/Websocket/Pusher.php
@@ -45,7 +45,7 @@ class Pusher
     protected $event;
 
     /**
-     * @var mixed|null
+     * @var string|null
      */
     protected $message;
 

--- a/src/Websocket/Pusher.php
+++ b/src/Websocket/Pusher.php
@@ -68,7 +68,7 @@ class Pusher
         bool $broadcast,
         bool $assigned,
         string $event,
-        $message = null,
+        ?string $message,
         $server
     )
     {


### PR DESCRIPTION
Add `?string` type to `$message`. This style of function declaration [has been deprecated in PHP 8.0](https://www.php.net/manual/en/migration80.deprecated.php).

solve issue: **[Is this a BUG?](https://github.com/swooletw/laravel-swoole/issues/472)**