### PR TITLE
fix could not working onTask when enabling task_enable_coroutine on swoole_http.php

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -260,11 +260,19 @@ class Manager
      *
      * @param mixed $server
      * @param string|\Swoole\Server\Task $taskId or $task
-     * @param string $srcWorkerId
-     * @param mixed $data
+     * @param string|null $srcWorkerId
+     * @param mixed|null $data
      */
-    public function onTask($server, $taskId, $srcWorkerId, $data)
+    public function onTask($server, $task, $srcWorkerId = null, $data = null)
     {
+        if ($task instanceof Task) {
+            $data = $task->data;
+            $srcWorkerId = $task->worker_id;
+            $taskId = $task->id;
+        } else {
+            $taskId = $task;
+        }
+
         $this->container->make('events')->dispatch('swoole.task', func_get_args());
 
         try {


### PR DESCRIPTION
I enabled `task_enable_coroutine` on swoole_http.php, it does not work because it will pass 2 arguments (`\Swoole\Server $server` and `Task $task` only), not 4 arguments when enabling `task_enable_coroutine`.

```
Symfony\Component\Debug\Exception\FatalErrorException:

Uncaught ArgumentCountError: Too few arguments to function SwooleTW\Http\Server\Manager::onTask(), 2 passed and exactly 4 expected in /var/www/html/vendor/swooletw/laravel-swoole/src/Server/Manager.php:266

   > 266|     public function onTask($server, $taskId, $srcWorkerId, $data)
     267|     {
     268|         $this->container->make('events')->dispatch('swoole.task', func_get_args());
     269|
     270|         try {
```


This commit will fix it.
