### PR TITLE
Fix: ref different coroutine id on same request

### DIFF
--- a/src/Coroutine/Context.php
+++ b/src/Coroutine/Context.php
@@ -28,7 +28,7 @@ class Context
      */
     public static function getApp()
     {
-        return static::$apps[static::getCoroutineId()] ?? null;
+        return static::$apps[static::getRequestedCoroutineId()] ?? null;
     }
 
     /**
@@ -38,7 +38,7 @@ class Context
      */
     public static function setApp(Container $app)
     {
-        static::$apps[static::getCoroutineId()] = $app;
+        static::$apps[static::getRequestedCoroutineId()] = $app;
     }
 
     /**
@@ -50,7 +50,7 @@ class Context
      */
     public static function getData(string $key)
     {
-        return static::$data[static::getCoroutineId()][$key] ?? null;
+        return static::$data[static::getRequestedCoroutineId()][$key] ?? null;
     }
 
     /**
@@ -61,7 +61,7 @@ class Context
      */
     public static function setData(string $key, $value)
     {
-        static::$data[static::getCoroutineId()][$key] = $value;
+        static::$data[static::getRequestedCoroutineId()][$key] = $value;
     }
 
     /**
@@ -71,7 +71,7 @@ class Context
      */
     public static function removeData(string $key)
     {
-        unset(static::$data[static::getCoroutineId()][$key]);
+        unset(static::$data[static::getRequestedCoroutineId()][$key]);
     }
 
     /**
@@ -79,7 +79,7 @@ class Context
      */
     public static function getDataKeys()
     {
-        return array_keys(static::$data[static::getCoroutineId()] ?? []);
+        return array_keys(static::$data[static::getRequestedCoroutineId()] ?? []);
     }
 
     /**
@@ -87,22 +87,27 @@ class Context
      */
     public static function clear()
     {
-        unset(static::$apps[static::getCoroutineId()]);
-        unset(static::$data[static::getCoroutineId()]);
+        unset(static::$apps[static::getRequestedCoroutineId()]);
+        unset(static::$data[static::getRequestedCoroutineId()]);
+    }
+
+    public static function getCoroutineId(): int
+    {
+        return Coroutine::getuid();
     }
 
     /**
-     * Get current requesting coroutine id.
+     * Get current coroutine id.
      */
-    public static function getCoroutineId(): int
+    public static function getRequestedCoroutineId(): int
     {
-        $currentId = Coroutine::getuid();
+        $currentId = static::getCoroutineId();
         if ($currentId === -1) {
             return -1;
         }
 
         $counter = 0;
-        while (($topCoroutineId = Coroutine::getPcid($currentId)) !== -1 && $counter <= self::MAX_RECURSE_COROUTINE_ID) {
+        while (($topCoroutineId = Coroutine::getPcid($currentId)) !== -1 && $counter <= static::MAX_RECURSE_COROUTINE_ID) {
             $currentId = $topCoroutineId;
             $counter++;
         }

--- a/src/Coroutine/Context.php
+++ b/src/Coroutine/Context.php
@@ -7,7 +7,7 @@ use Swoole\Coroutine;
 
 class Context
 {
-    protected const MAX_RECURSE_CONTEXT_ID = 50;
+    protected const MAX_RECURSE_COROUTINE_ID = 50;
 
     /**
      * The app containers in different coroutine environment.
@@ -102,7 +102,7 @@ class Context
         }
 
         $counter = 0;
-        while (($topCoroutineId = Coroutine::getPcid($currentId)) !== -1 && $counter <= self::MAX_RECURSE_CONTEXT_ID) {
+        while (($topCoroutineId = Coroutine::getPcid($currentId)) !== -1 && $counter <= self::MAX_RECURSE_COROUTINE_ID) {
             $currentId = $topCoroutineId;
             $counter++;
         }

--- a/tests/Coroutine/ContextTest.php
+++ b/tests/Coroutine/ContextTest.php
@@ -63,12 +63,12 @@ class ContextTest extends TestCase
 
             $data1 = Context::getData('foo');
             $data2 = 'baz';
-            $coroutineId1 = Context::getCoroutineId();
+            $coroutineId1 = Context::getRequestedCoroutineId();
             $coroutineId2 = -1;
 
             go(function () use (&$data2, &$coroutineId2) {
                 $data2 = Context::getData('foo');
-                $coroutineId2 = Context::getCoroutineId();
+                $coroutineId2 = Context::getRequestedCoroutineId();
             });
         });
 

--- a/tests/Coroutine/ContextTest.php
+++ b/tests/Coroutine/ContextTest.php
@@ -56,25 +56,41 @@ class ContextTest extends TestCase
     {
         $data1 = null;
         $data2 = null;
+        $data3 = null;
+
         $coroutineId1 = null;
         $coroutineId2 = null;
-        \Swoole\Coroutine\run(function () use (&$data1, &$data2, &$coroutineId1, &$coroutineId2) {
+        $coroutineId3 = null;
+
+        \Swoole\Coroutine\run(function () use (&$data1, &$data2, &$data3, &$coroutineId1, &$coroutineId2, &$coroutineId3) {
             Context::setData('foo', 'bar');
 
             $data1 = Context::getData('foo');
             $data2 = 'baz';
+            $data2 = 'swoole';
+
             $coroutineId1 = Context::getRequestedCoroutineId();
             $coroutineId2 = -1;
+            $coroutineId3 = -1;
 
-            go(function () use (&$data2, &$coroutineId2) {
+            go(function () use (&$data2, &$data3, &$coroutineId2, &$coroutineId3) {
                 $data2 = Context::getData('foo');
                 $coroutineId2 = Context::getRequestedCoroutineId();
+
+                // test nested coroutine
+                go(function () use (&$data3, &$coroutineId3) {
+                    $data3 = Context::getData('foo');
+                    $coroutineId3 = Context::getRequestedCoroutineId();
+                });
             });
         });
 
         $this->assertSame('bar', $data1);
         $this->assertSame($data1, $data2);
+        $this->assertSame($data2, $data3);
         $this->assertSame($coroutineId1, $coroutineId2);
+        $this->assertSame($coroutineId2, $coroutineId3);
+
     }
 
     public function testClear()

--- a/tests/Coroutine/ContextTest.php
+++ b/tests/Coroutine/ContextTest.php
@@ -52,6 +52,31 @@ class ContextTest extends TestCase
         $this->assertSame(['foo', 'sea'], Context::getDataKeys());
     }
 
+    public function testGetDataKeyInCoroutine()
+    {
+        $data1 = null;
+        $data2 = null;
+        $coroutineId1 = null;
+        $coroutineId2 = null;
+        \Swoole\Coroutine\run(function () use (&$data1, &$data2, &$coroutineId1, &$coroutineId2) {
+            Context::setData('foo', 'bar');
+
+            $data1 = Context::getData('foo');
+            $data2 = 'baz';
+            $coroutineId1 = Context::getCoroutineId();
+            $coroutineId2 = -1;
+
+            go(function () use (&$data2, &$coroutineId2) {
+                $data2 = Context::getData('foo');
+                $coroutineId2 = Context::getCoroutineId();
+            });
+        });
+
+        $this->assertSame('bar', $data1);
+        $this->assertSame($data1, $data2);
+        $this->assertSame($coroutineId1, $coroutineId2);
+    }
+
     public function testClear()
     {
         Context::setApp(m::mock(Container::class));


### PR DESCRIPTION
In same request, `Context::getCoroutineId` will return diffirent value when using it on different coroutines.
This problem is easy to make a mistake when using coroutines with laravel-swoole.

For example is below:
```php
// ...

$request1 = $sandbox->getRequest();

go(function () use ($sandbox) {
    // $request1 and $request2 are different reference because coroutine ids are not same.
    $request2 = $sandbox->getRequest();
});

// ...
```

and another way:

```php
// ...

$value1 = Context::getData('foo');

go(function () use ($sandbox) {
    // $value1 and $value2 are different reference because coroutine ids are not same.
    $value2 = Context::getData('foo');
});

// ...
```


This PR is fixed it.


