### PR TITLE
Websocket - Sandbox missing for disconnect event

### DIFF
--- a/src/Concerns/InteractsWithWebsocket.php
+++ b/src/Concerns/InteractsWithWebsocket.php
@@ -161,9 +161,14 @@ trait InteractsWithWebsocket
         }
 
         $websocket = $this->app->make(Websocket::class);
+        $sandbox = $this->app->make(Sandbox::class);
 
         try {
             $websocket->reset(true)->setSender($fd);
+            
+            // enable sandbox
+            $sandbox->enable();
+            
             // trigger 'disconnect' websocket event
             if ($websocket->eventExists('disconnect')) {
                 $websocket->call('disconnect');
@@ -174,6 +179,9 @@ trait InteractsWithWebsocket
             $websocket->leave();
         } catch (Throwable $e) {
             $this->logServerError($e);
+        } finally {
+            // disable and recycle sandbox resource
+            $sandbox->disable();
         }
     }
 


### PR DESCRIPTION
Sandbox must be created even when disconnect event is dispatched, because for example the providers are not set otherwise. In my specific case, I would like to log the disconnection of the user, but authentication guards do not work without this.