### PR TITLE
Solved problem on __construct parameter

### DIFF
--- a/src/Websocket/Pusher.php
+++ b/src/Websocket/Pusher.php
@@ -68,8 +68,8 @@ class Pusher
         bool $broadcast,
         bool $assigned,
         string $event,
-        $message = null,
-        $server
+        $server,
+        $message = null
     )
     {
         $this->opcode = $opcode;
@@ -99,8 +99,8 @@ class Pusher
             $data['broadcast'] ?? false,
             $data['assigned'] ?? false,
             $data['event'] ?? null,
-            $data['message'] ?? null,
-            $server
+            $server,
+            $data['message'] ?? null
         );
     }
 


### PR DESCRIPTION
Get this : ErrorException: Required parameter $server follows optional parameter $message in /var/www/html/test/LumenWebSocket/vendor/swooletw/laravel-swoole/src/Websocket/Pusher.php:64

To solve this problem, it is better to move the variables.