### PR TITLE
Fix: task worker num output zero always and enable task worker when defined connections in queue.php

### DIFF
--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -220,7 +220,7 @@ class HttpServerCommand extends Command
         $taskWorkerNum = Arr::get($this->config, 'server.options.task_worker_num');
         $isWebsocket = Arr::get($this->config, 'websocket.enabled');
 
-        // lookup for settled swoole driver
+        // lookup for set swoole driver
         $isDefinedSwooleDriver = in_array(
             'swoole',
             array_column(

--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -219,7 +219,19 @@ class HttpServerCommand extends Command
         $workerNum = Arr::get($this->config, 'server.options.worker_num');
         $taskWorkerNum = Arr::get($this->config, 'server.options.task_worker_num');
         $isWebsocket = Arr::get($this->config, 'websocket.enabled');
-        $hasTaskWorker = $isWebsocket || Arr::get($this->config, 'queue.default') === 'swoole';
+
+        // lookup for settled swoole driver
+        $isDefinedSwooleDriver = in_array(
+                'swoole',
+                array_column(
+                    $queueConfig['connections'] ?? [],
+                    'driver'
+                ),
+                true
+            ) || ($queueConfig['default'] ?? null) === 'swoole';
+
+        $hasTaskWorker = $isWebsocket || $isDefinedSwooleDriver;
+
         $logFile = Arr::get($this->config, 'server.options.log_file');
         $pids = $this->laravel->make(PidManager::class)->read();
         $masterPid = $pids['masterPid'] ?? null;

--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -220,6 +220,8 @@ class HttpServerCommand extends Command
         $taskWorkerNum = Arr::get($this->config, 'server.options.task_worker_num');
         $isWebsocket = Arr::get($this->config, 'websocket.enabled');
 
+        $queueConfig = $this->laravel->make('config')->get('queue');
+        
         // lookup for set swoole driver
         $isDefinedSwooleDriver = in_array(
             'swoole',

--- a/src/Commands/HttpServerCommand.php
+++ b/src/Commands/HttpServerCommand.php
@@ -222,13 +222,13 @@ class HttpServerCommand extends Command
 
         // lookup for settled swoole driver
         $isDefinedSwooleDriver = in_array(
-                'swoole',
-                array_column(
-                    $queueConfig['connections'] ?? [],
-                    'driver'
-                ),
-                true
-            ) || ($queueConfig['default'] ?? null) === 'swoole';
+            'swoole',
+            array_column(
+                $queueConfig['connections'] ?? [],
+                'driver'
+            ),
+            true
+        ) || ($queueConfig['default'] ?? null) === 'swoole';
 
         $hasTaskWorker = $isWebsocket || $isDefinedSwooleDriver;
 

--- a/src/HttpServiceProvider.php
+++ b/src/HttpServiceProvider.php
@@ -181,8 +181,18 @@ abstract class HttpServiceProvider extends ServiceProvider
         $config = $this->app->make('config');
         $options = $config->get('swoole_http.server.options');
 
+        // lookup for settled swoole driver
+        $isDefinedSwooleDriver = in_array(
+            'swoole',
+            array_column(
+                $config->get('queue.connections'),
+                'driver'
+            ),
+            true
+        ) || $config->get('queue.default') === 'swoole';
+
         // only enable task worker in websocket mode and for queue driver
-        if ($config->get('queue.default') !== 'swoole' && ! $this->isWebsocket) {
+        if (! $isDefinedSwooleDriver && ! $this->isWebsocket) {
             unset($options['task_worker_num']);
         }
 

--- a/src/HttpServiceProvider.php
+++ b/src/HttpServiceProvider.php
@@ -181,7 +181,7 @@ abstract class HttpServiceProvider extends ServiceProvider
         $config = $this->app->make('config');
         $options = $config->get('swoole_http.server.options');
 
-        // lookup for settled swoole driver
+        // lookup for set swoole driver
         $isDefinedSwooleDriver = in_array(
             'swoole',
             array_column(


### PR DESCRIPTION
I fixed:

1. `Task Worker Num` is output zero always when using `php artisan swoole:http infos`.
   - because $this->config cannot access to queue.php.
2. Did not start task worker (always unset the defined value) when defining connections in queue.php because the laravel-swoole refer `queue.default` only.

In my use-case, I want to set default SQS (AWS), but another way, I want to use swoole's task worker.
However, the laravel-swoole did not run task worker because the reason is above.