### PR TITLE
Clear auth instance on every requests

### DIFF
--- a/config/swoole_http.php
+++ b/config/swoole_http.php
@@ -81,7 +81,7 @@ return [
     'pre_resolved' => [
         'view', 'files', 'session', 'session.store', 'routes',
         'db', 'db.factory', 'cache', 'cache.store', 'config', 'cookie',
-        'encrypter', 'hash', 'router', 'translator', 'url', 'log', 'auth',
+        'encrypter', 'hash', 'router', 'translator', 'url', 'log',
     ],
 
     /*
@@ -90,7 +90,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'instances' => [
-        //
+        'auth',
     ],
 
     /*


### PR DESCRIPTION
Currenly auth instance is resseting after swoole reload/restart, and after user login - it shares auth across all other requests.

This commit fixes:
1) Logout user after swoole reload
2) Share auth instance across all requests