### PR TITLE
Clear auth instance on every requests

### DIFF
--- a/config/swoole_http.php
+++ b/config/swoole_http.php
@@ -81,7 +81,7 @@ return [
     'pre_resolved' => [
         'view', 'files', 'session', 'session.store', 'routes',
         'db', 'db.factory', 'cache', 'cache.store', 'config', 'cookie',
-        'encrypter', 'hash', 'router', 'translator', 'url', 'log', 'auth',
+        'encrypter', 'hash', 'router', 'translator', 'url', 'log',
     ],
 
     /*
@@ -90,7 +90,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'instances' => [
-        //
+        'auth',
     ],
 
     /*


### PR DESCRIPTION
Currenly auth instance is setting after swoole reload/restart, so user auth shares across all other requests.

It's rollback for commit 3a93e92c8b8ad5eed8bbdf4398faa22bdef48b4f by @Arkanius 
Putting Auth instance in pre_resolved array makes it the same instance between different user requests.
Tested on clean Laravel 8 install.

This commit fixes:
1) Logout user after swoole reload
2) Share auth instance across all requests



**Take a look into documentation:**
![image](https://user-images.githubusercontent.com/22893424/140653742-481a77ed-c59f-45c0-929b-4e2afd4561cd.png)

**And into code of `SwooleTW\Http\Concerns\WithApplication`**

![image](https://user-images.githubusercontent.com/22893424/140653896-d9d38f55-9998-4e47-acab-2dd5534030ed.png)

