### PR TITLE
convert request to lumen request on lumen application

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use SwooleTW\Http\Concerns\InteractsWithSwooleQueue;
 use SwooleTW\Http\Concerns\InteractsWithSwooleTable;
 use Symfony\Component\ErrorHandler\Error\FatalError;
+use Laravel\Lumen\Http\Request as LumenRequest;
 
 /**
  * Class Manager
@@ -214,6 +215,10 @@ class Manager
             }
             // transform swoole request to illuminate request
             $illuminateRequest = Request::make($swooleRequest)->toIlluminate();
+
+            if (!$sandbox->isLaravel()) { // is lumen app
+                $illuminateRequest = LumenRequest::createFromBase($illuminateRequest);
+            }
 
             // set current request to sandbox
             $sandbox->setRequest($illuminateRequest);


### PR DESCRIPTION
fix issue when accessing property of $request in lumen application

step to reproduce :  create a simple controller 

```
public function simpleAPI(Request $request)
{
    return response()->json([ 'data'  =>  $request->myproperty  ]);
}
```

expected :  

`{ 'data' : null } `

got : 

```
Symfony Exception :

Call to a member function parameter() on arrayCall to a member function parameter() on array on vendor/illuminate/http/Request.php (line 568)

```
