### PR TITLE
Fix deprecated null potentially being passed to strpos()

### DIFF
--- a/src/Transformers/Request.php
+++ b/src/Transformers/Request.php
@@ -92,7 +92,7 @@ class Request
 
         $request = new SymfonyRequest($get, $post, [], $cookie, $files, $server, $content);
 
-        if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+        if (0 === strpos($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'])
         ) {
             parse_str($request->getContent(), $data);


### PR DESCRIPTION
Fixes this notice coming from PHP 8.1:

```
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/vendor/swooletw/laravel-swoole/src/Transformers/Request.php on line 95
```