### PR TITLE
Handling null event in websockets

### DIFF
--- a/src/Concerns/InteractsWithWebsocket.php
+++ b/src/Concerns/InteractsWithWebsocket.php
@@ -136,9 +136,11 @@ trait InteractsWithWebsocket
 
             // dispatch message to registered event callback
             ['event' => $event, 'data' => $data] = $payload;
-            $websocket->eventExists($event)
-                ? $websocket->call($event, $data)
-                : $this->websocketHandler->onMessage($frame);
+            if ($event and $websocket->eventExists($event)) {
+                $websocket->call($event, $data);
+            } else {
+                $this->websocketHandler->onMessage($frame);
+            }
         } catch (Throwable $e) {
             $this->logServerError($e);
         } finally {


### PR DESCRIPTION
Hi
When using a custom websocket protocol and `SimpleParser`, if there is no `event`, there will be an fatal error about passing null to `Websocket::on(string $event, $callback)`.
This PR fix the problem and prevent calling `on()` method.