### PR TITLE
Fix laravel/framework version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "illuminate/http": ">=5.4",
     "illuminate/support": ">=5.4",
     "predis/predis": "^1.1",
-    "laravel/framework":"v5.4"
+    "laravel/framework":">=5.4"
   },
   "require-dev": {
     "laravel/lumen-framework": ">=5.4",


### PR DESCRIPTION
After merging #544 this package is incompatible with Laravel >= 6.
This PR `laravel/framework` version requirement.